### PR TITLE
Some colored enhancements

### DIFF
--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -1,4 +1,5 @@
 require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
+require 'set'
 
 ##
 # cute.
@@ -15,6 +16,10 @@ require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
 module Colored
   extend self
 
+  ###########################################################################
+  
+  IS_TTY = STDOUT.isatty
+
   COLORS = { 
     'black'   => 30,
     'red'     => 31, 
@@ -29,10 +34,41 @@ module Colored
   EXTRAS = {
     'clear'     => 0, 
     'bold'      => 1,
+    'light'     => 1,
     'underline' => 4,
     'reversed'  => 7
   }
   
+  #
+  # BBS-style numeric color codes.
+  #
+  BBS_COLOR_TABLE = {
+    0   => :black,
+    1   => :blue,
+    2   => :green,
+    3   => :cyan,
+    4   => :red,
+    5   => :magenta,
+    6   => :yellow,
+    7   => :white,
+    8   => :light_black,
+    9   => :light_blue,
+    10  => :light_green,
+    11  => :light_cyan,
+    12  => :light_red,
+    13  => :light_magenta,
+    14  => :light_yellow,
+    15  => :light_white,
+  }
+
+  VALID_COLORS = Set.new(
+    COLORS.keys +
+    COLORS.map { |k,v| "light_#{k}" } +
+    COLORS.map { |k,v| "bold_#{k}"  }
+  )
+  
+  ###########################################################################
+
   COLORS.each do |color, value|
     define_method(color) do 
       colorize(self, :foreground => color)
@@ -40,6 +76,10 @@ module Colored
 
     define_method("on_#{color}") do
       colorize(self, :background => color)
+    end
+
+    define_method("light_#{color}") do
+      colorize(self, :foreground => color, :extra => 'bold')
     end
 
     COLORS.each do |highlight, value|
@@ -65,10 +105,20 @@ module Colored
     tmp
   end
 
-  def colorize(string, options = {})
-    colored = [color(options[:foreground]), color("on_#{options[:background]}"), extra(options[:extra])].compact * ''
-    colored << string
-    colored << extra(:clear)
+  ###########################################################################
+
+  def colorize(string=nil, options = {})
+    if string == nil
+      return tagged_colors(self)
+    end
+    
+    if IS_TTY
+      colored = [color(options[:foreground]), color("on_#{options[:background]}"), extra(options[:extra])].compact * ''
+      colored << string
+      colored << extra(:clear)
+    else
+      string
+    end
   end
 
   def colors
@@ -86,6 +136,75 @@ module Colored
     return unless color_name && COLORS[color_name]
     "\e[#{COLORS[color_name] + (background ? 10 : 0)}m" 
   end
+
+  ###########################################################################
+  
+  #
+  # Is this string legal?
+  #     
+  def valid_tag?(tag)
+    VALID_COLORS.include?(tag) or
+    (
+      string =~ /^\d+$/ and
+      BBS_COLOR_TABLE.include?(tag.to_i)
+    )
+  end
+    
+  #
+  # Colorize a string that has "color tags".
+  #
+  # Examples:
+  #
+  # Colors as words:
+  #    puts "<light_yellow><light_white>*</light_white> Hey mom! I am <light_green>SO</light_green> colourized right now.</light_yellow>".colorize
+  #
+  # Numeric ANSI colors (from the BBS days):
+  #    puts "<10><5>*</5> Hey mom! I am <9>SO</9> colourized right now.</10>".colorize
+  #
+  def tagged_colors(string)
+    stack = []
+
+    # split the string into tags and literal strings
+    tokens          = string.split(/(<\/?[\w\d_]+>)/)
+    tokens.delete_if { |token| token.size == 0 }
+    
+    result        = ""
+
+    tokens.each do |token|
+
+      # token is an opening tag!
+      
+      if /<([\w\d_]+)>/ =~ token and valid_tag?($1)
+        stack.push $1
+
+      # token is a closing tag!      
+      
+      elsif /<\/([\w\d_]+)>/ =~ token and valid_tag?($1)
+
+        # if this color is on the stack somwehere...
+        if pos = stack.rindex($1)
+          # close the tag by removing it from the stack
+          stack.delete_at pos
+        else
+          raise "Error: tried to close an unopened color tag -- #{token}"
+        end
+
+      # token is a literal string!
+      
+      else
+
+        color = (stack.last || "white")
+        color = BBS_COLOR_TABLE[color.to_i] if color =~ /^\d+$/
+        result << token.send(color)
+        
+      end
+      
+    end
+    
+    result
+  end  
+
+
 end unless Object.const_defined? :Colored
 
 String.send(:include, Colored)

--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -18,7 +18,7 @@ module Colored
 
   ###########################################################################
   
-  IS_TTY = STDOUT.isatty
+  @@is_tty = STDOUT.isatty
 
   COLORS = { 
     'black'   => 30,
@@ -112,7 +112,7 @@ module Colored
       return tagged_colors(self)
     end
     
-    if IS_TTY
+    if @@is_tty
       colored = [color(options[:foreground]), color("on_#{options[:background]}"), extra(options[:extra])].compact * ''
       colored << string
       colored << extra(:clear)
@@ -138,6 +138,20 @@ module Colored
   end
 
   ###########################################################################
+
+  def enable!
+    @@is_tty = true
+  end
+  
+  alias_method :force!, :enable!
+  
+  def disable!
+    @@is_tty = false
+  end
+
+  def is_tty?
+    @@is_tty
+  end
   
   #
   # Is this string legal?

--- a/test/colored_test.rb
+++ b/test/colored_test.rb
@@ -49,4 +49,17 @@ class TestColor < Test::Unit::TestCase
     assert_equal  "<light_blue>text</light_blue>".colorize, 
                   "text".light_blue
   end
+  
+  def test_tty_detection
+    Colored.enable!
+    assert_equal Colored.is_tty?, true
+    assert_equal "\e[31mred\e[0m", "red".red
+
+    Colored.disable!
+    assert_equal Colored.is_tty?, false
+    assert_equal "red", "red".red
+
+    Colored.force!
+    assert_equal "\e[31mred\e[0m", "red".red
+  end
 end

--- a/test/colored_test.rb
+++ b/test/colored_test.rb
@@ -41,4 +41,12 @@ class TestColor < Test::Unit::TestCase
   def test_eol_with_modifiers_stack_with_colors
     assert_equal "\e[36m\e[4m\e[1m\e[2Kcyan underlined bold\e[0m\e[0m\e[0m", "cyan underlined bold".bold.underline.cyan.to_eol
   end
+  
+  def test_tagged_colors
+    assert_equal  "<blue>text</blue>".colorize, 
+                  "text".blue
+
+    assert_equal  "<light_blue>text</light_blue>".colorize, 
+                  "text".light_blue
+  end
 end


### PR DESCRIPTION
Myello there!

I added some features to colored that I thought would be useful (mostly to me, but hopefully to others):
- Detect whether STDOUT is a tty or a pipe, and disable colors if it's a pipe. (Can be overridden by `Colored.force!` or `Colored.enable!`)
- Let the user specify colors using tags. (I added this because it makes writing a apps that highlight substring matches much easier. eg: `string.gsub(pattern) { |match| "<yellow>#{match}</yellow>" }.colorize`)
- BBS-style color codes for the tagged colours (eg: `"<4>red</4>, <1>blue</1>, <13>light magenta</13>, etc..".colorize`), for those who still remember the DOS color palette and want more terse tagged-colors.

If there's anything that you think I should clean up, I'd be happy to. I'd love to see these features in colored!
