### PR TITLE
Check for tty before coloring

### DIFF
--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -1,17 +1,4 @@
-require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
-
-##
-# cute.
-# 
-#   >> "this is red".red
-#  
-#   >> "this is red with a blue background (read: ugly)".red_on_blue
-#
-#   >> "this is red with an underline".red.underline
-#
-#   >> "this is really bold and really blue".bold.blue
-#
-#   >> Colored.red "This is red" # but this part is mostly untested
+# from https://github.com/defunkt/colored
 module Colored
   extend self
 
@@ -77,13 +64,14 @@ module Colored
 
   def extra(extra_name)
     extra_name = extra_name.to_s
-    "\e[#{EXTRAS[extra_name]}m" if EXTRAS[extra_name]
+    "\e[#{EXTRAS[extra_name]}m" if EXTRAS[extra_name] && $stdout.tty?
+    ""
   end
 
   def color(color_name)
     background = color_name.to_s =~ /on_/
     color_name = color_name.to_s.sub('on_', '')
-    return unless color_name && COLORS[color_name]
+    return unless color_name && COLORS[color_name] && $stdout.tty?
     "\e[#{COLORS[color_name] + (background ? 10 : 0)}m" 
   end
 end unless Object.const_defined? :Colored

--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -1,4 +1,17 @@
-# from https://github.com/defunkt/colored
+require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
+
+##
+# cute.
+#
+#   >> "this is red".red
+#
+#   >> "this is red with a blue background (read: ugly)".red_on_blue
+#
+#   >> "this is red with an underline".red.underline
+#
+#   >> "this is really bold and really blue".bold.blue
+#
+#   >> Colored.red "This is red" # but this part is mostly untested
 module Colored
   extend self
 

--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -77,7 +77,7 @@ module Colored
 
   def extra(extra_name)
     extra_name = extra_name.to_s
-    "\e[#{EXTRAS[extra_name]}m" if EXTRAS[extra_name] && $stdout.tty?
+    return "\e[#{EXTRAS[extra_name]}m" if EXTRAS[extra_name] && $stdout.tty?
     ""
   end
 


### PR DESCRIPTION
This accounts for redirecting (for example for log files). So the string only gets colored if the user is going to see it, otherwise we don't color to prevent cruft in log files.
