### PR TITLE
Remove Ruby warning

### DIFF
--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -2,9 +2,9 @@ require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
 
 ##
 # cute.
-# 
+#
 #   >> "this is red".red
-#  
+#
 #   >> "this is red with a blue background (read: ugly)".red_on_blue
 #
 #   >> "this is red with an underline".red.underline
@@ -15,10 +15,10 @@ require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
 module Colored
   extend self
 
-  COLORS = { 
+  COLORS = {
     'black'   => 30,
-    'red'     => 31, 
-    'green'   => 32, 
+    'red'     => 31,
+    'green'   => 32,
     'yellow'  => 33,
     'blue'    => 34,
     'magenta' => 35,
@@ -27,14 +27,14 @@ module Colored
   }
 
   EXTRAS = {
-    'clear'     => 0, 
+    'clear'     => 0,
     'bold'      => 1,
     'underline' => 4,
     'reversed'  => 7
   }
-  
+
   COLORS.each do |color, value|
-    define_method(color) do 
+    define_method(color) do
       colorize(self, :foreground => color)
     end
 
@@ -52,7 +52,7 @@ module Colored
 
   EXTRAS.each do |extra, value|
     next if extra == 'clear'
-    define_method(extra) do 
+    define_method(extra) do
       colorize(self, :extra => extra)
     end
   end
@@ -84,7 +84,7 @@ module Colored
     background = color_name.to_s =~ /on_/
     color_name = color_name.to_s.sub('on_', '')
     return unless color_name && COLORS[color_name]
-    "\e[#{COLORS[color_name] + (background ? 10 : 0)}m" 
+    "\e[#{COLORS[color_name] + (background ? 10 : 0)}m"
   end
 end unless Object.const_defined? :Colored
 

--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -42,7 +42,7 @@ module Colored
       colorize(self, :background => color)
     end
 
-    COLORS.each do |highlight, value|
+    COLORS.each_key do |highlight|
       next if color == highlight
       define_method("#{color}_on_#{highlight}") do
         colorize(self, :foreground => color, :background => highlight)

--- a/test/colored_test.rb
+++ b/test/colored_test.rb
@@ -15,7 +15,7 @@ class TestColor < Test::Unit::TestCase
   end
 
   def test_hot_color_on_color_action
-    assert_equal "\e[31m\e[44mred on blue\e[0m", "red on blue".red_on_blue 
+    assert_equal "\e[31m\e[44mred on blue\e[0m", "red on blue".red_on_blue
   end
 
   def test_modifier


### PR DESCRIPTION
Just getting rid of this annoying Ruby warning: `lib/colored.rb:45: warning: shadowing outer local variable - value`.

Also added a commit trimming trailing white spaces - feel free to cherry-pick only the first one if you're not interested.
