### PR TITLE
Adding licence to gemspec

### DIFF
--- a/colored.gemspec
+++ b/colored.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.files             = %w( README Rakefile LICENSE )
   s.files            += Dir.glob("lib/**/*")
   s.files            += Dir.glob("test/**/*")
+  s.licenses          = ["MIT"]
   s.description       = <<-desc
   >> puts "this is red".red
  


### PR DESCRIPTION
You have what looks like a MIT licence on this package. I am proposing this change because it makes it easier for tools like gem2rpm to work out what to do.
