### PR TITLE
TTY detection

### DIFF
--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -76,15 +76,21 @@ module Colored
   end
 
   def extra(extra_name)
+    return "" unless is_tty
     extra_name = extra_name.to_s
     "\e[#{EXTRAS[extra_name]}m" if EXTRAS[extra_name]
   end
 
   def color(color_name)
+    return unless is_tty
     background = color_name.to_s =~ /on_/
     color_name = color_name.to_s.sub('on_', '')
     return unless color_name && COLORS[color_name]
-    "\e[#{COLORS[color_name] + (background ? 10 : 0)}m" 
+    "\e[#{COLORS[color_name] + (background ? 10 : 0)}m"
+  end
+
+  def is_tty()
+    $stdout.tty?
   end
 end unless Object.const_defined? :Colored
 

--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -32,6 +32,8 @@ module Colored
     'underline' => 4,
     'reversed'  => 7
   }
+
+  @@enforced_colors = nil
   
   COLORS.each do |color, value|
     define_method(color) do 
@@ -90,7 +92,12 @@ module Colored
   end
 
   def is_tty()
-    $stdout.tty?
+    return $stdout.tty? unless not @@enforced_colors.nil?
+    @@enforced_colors
+  end
+
+  def enforce_colors(x)
+    @@enforced_colors = x
   end
 end unless Object.const_defined? :Colored
 

--- a/test/colored_test.rb
+++ b/test/colored_test.rb
@@ -1,6 +1,8 @@
 require 'test/unit'
 require File.dirname(__FILE__) + '/../lib/colored'
 
+Colored.enforce_colors(true)
+
 class TestColor < Test::Unit::TestCase
   def test_one_color
     assert_equal "\e[31mred\e[0m", "red".red
@@ -40,5 +42,11 @@ class TestColor < Test::Unit::TestCase
 
   def test_eol_with_modifiers_stack_with_colors
     assert_equal "\e[36m\e[4m\e[1m\e[2Kcyan underlined bold\e[0m\e[0m\e[0m", "cyan underlined bold".bold.underline.cyan.to_eol
+  end
+
+  def test_colors_on_tty_only
+    Colored.enforce_colors(false)
+    assert_equal "red", "red".red
+    Colored.enforce_colors(true)
   end
 end


### PR DESCRIPTION
I rewrote @egonSchiele's tty fix. Thanks for the original pull request in #4!

I added an `enforced_colors` option to bypass the tty check during tests.

I dislike my is_tty method, somebody with better ruby skills is welcome to rewrite it.
