### PR TITLE
Add uncolorize method to remove escape sequences

### DIFF
--- a/lib/colored.rb
+++ b/lib/colored.rb
@@ -71,6 +71,11 @@ module Colored
     colored << extra(:clear)
   end
 
+  def uncolorize
+    # http://refiddle.com/18rj
+    gsub /\e\[\d+(;\d+)*m/, ''
+  end
+
   def colors
     @@colors ||= COLORS.keys.sort
   end


### PR DESCRIPTION
Since colorize always wraps the string existing colors can't be changed. This new method makes it possible to remove existing color sequences so colors can be changed.
