### PR TITLE
Added license information to gemspec

### DIFF
--- a/colored.gemspec
+++ b/colored.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.homepage          = "http://github.com/defunkt/colored"
   s.email             = "chris@ozmm.org"
   s.authors           = ["Chris Wanstrath"]
+  s.license           = 'MIT'
   s.has_rdoc          = false
   s.require_path      = "lib"
   s.files             = %w( README Rakefile LICENSE )


### PR DESCRIPTION
I'm performing a license audit on some gems, and I noticed your gem does not specify the license on the gemspec.

Since your LICENSE file is a MIT license, I added this information on the gemspec.
